### PR TITLE
feat: 홈에 신고/문의 처리 현황 표시

### DIFF
--- a/src/api/dashboard.server.ts
+++ b/src/api/dashboard.server.ts
@@ -1,0 +1,10 @@
+import "server-only";
+import { createClient } from "@/api/client";
+
+export async function getDashboardSummary() {
+  const supabase = await createClient();
+
+  const { data } = await supabase.rpc("get_dashboard_summary");
+
+  return { data };
+}

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -10,9 +10,9 @@ export async function loginAction(formData: FormData) {
   // 폼 내용으로 로그인 시도
   const res = await login(email, password);
 
-  // 로그인 성공 시, 사용자 신고 페이지로 이동
+  // 로그인 성공 시, 홈으로 이동
   if (res.ok) {
-    redirect("/user-reports");
+    redirect("/");
   }
 
   // 로그인 실패 시, 쿼리스트링으로 실패 전달

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,13 @@
+import { getDashboardSummary } from "@/api/dashboard.server";
 import Header from "@/components/Header";
 import Main from "@/components/Main";
 import SubTitle from "@/components/SubTitle";
 import StatusSummaryCard from "@/features/StatusSummaryCard";
 
-export default function Home() {
+export default async function Home() {
+  const { data: summary } = await getDashboardSummary();
+  const { reports, inquiries } = summary;
+
   return (
     <>
       <Header />
@@ -14,13 +18,21 @@ export default function Home() {
           <SubTitle>처리 현황</SubTitle>
 
           <div className="flex flex-col gap-2 md:flex-row md:gap-10">
-            <StatusSummaryCard content="신고 미처리" count={3} />
             <StatusSummaryCard
-              content="문의 미처리"
-              isTodayUpdated
-              count={24}
+              content="사용자 신고"
+              isTodayUpdated={reports.user.hasToday}
+              count={reports.user.pendingCount}
             />
-            <StatusSummaryCard content="문의 진행중" count={7} color="blue" />
+            <StatusSummaryCard
+              content="게시글/댓글 신고"
+              isTodayUpdated={reports.content.hasToday}
+              count={reports.content.pendingCount}
+            />
+            <StatusSummaryCard
+              content="문의"
+              isTodayUpdated={inquiries.hasToday}
+              count={inquiries.pendingCount}
+            />
           </div>
         </section>
       </Main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,29 @@
-import { redirect } from "next/navigation";
+import Header from "@/components/Header";
+import Main from "@/components/Main";
+import SubTitle from "@/components/SubTitle";
+import StatusSummaryCard from "@/features/StatusSummaryCard";
 
 export default function Home() {
-  redirect("/user-reports");
+  return (
+    <>
+      <Header />
+
+      <Main>
+        {/* 신고/문의 처리 현황 */}
+        <section className="flex flex-col">
+          <SubTitle>처리 현황</SubTitle>
+
+          <div className="flex flex-col gap-2 md:flex-row md:gap-10">
+            <StatusSummaryCard content="신고 미처리" count={3} />
+            <StatusSummaryCard
+              content="문의 미처리"
+              isTodayUpdated
+              count={24}
+            />
+            <StatusSummaryCard content="문의 진행중" count={7} color="blue" />
+          </div>
+        </section>
+      </Main>
+    </>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,16 +19,19 @@ export default async function Home() {
 
           <div className="flex flex-col gap-2 md:flex-row md:gap-10">
             <StatusSummaryCard
+              href={"/user-reports?status=pending"}
               content="사용자 신고"
               isTodayUpdated={reports.user.hasToday}
               count={reports.user.pendingCount}
             />
             <StatusSummaryCard
+              href={"/content-reports?status=pending"}
               content="게시글/댓글 신고"
               isTodayUpdated={reports.content.hasToday}
               count={reports.content.pendingCount}
             />
             <StatusSummaryCard
+              href={"/inquiries?status=pending"}
               content="문의"
               isTodayUpdated={inquiries.hasToday}
               count={inquiries.pendingCount}

--- a/src/features/StatusSummaryCard.tsx
+++ b/src/features/StatusSummaryCard.tsx
@@ -1,10 +1,14 @@
+import Link, { type LinkProps } from "next/link";
+
 interface Props {
+  href: LinkProps["href"];
   content: string;
   isTodayUpdated?: boolean;
   count: number;
 }
 
 export default function StatusSummaryCard({
+  href,
   content,
   isTodayUpdated = false,
   count,
@@ -12,7 +16,10 @@ export default function StatusSummaryCard({
   const hasCount = count > 0;
 
   return (
-    <div className="flex min-w-0 flex-1 items-center rounded-lg bg-gray-100 px-7 py-4 md:px-9 md:py-6">
+    <Link
+      className="flex min-w-0 flex-1 items-center rounded-lg bg-gray-100 px-7 py-4 decoration-1 underline-offset-2 hover:underline md:px-9 md:py-6"
+      href={href}
+    >
       {/* 항목 이름 */}
       <span>{content}</span>
 
@@ -31,6 +38,6 @@ export default function StatusSummaryCard({
       >
         {count}
       </span>
-    </div>
+    </Link>
   );
 }

--- a/src/features/StatusSummaryCard.tsx
+++ b/src/features/StatusSummaryCard.tsx
@@ -1,0 +1,41 @@
+interface Props {
+  content: string;
+  isTodayUpdated?: boolean;
+  count: number;
+  color?: "red" | "blue";
+}
+
+export default function StatusSummaryCard({
+  content,
+  isTodayUpdated = false,
+  count,
+  color = "red",
+}: Props) {
+  const colorStyle: Record<NonNullable<Props["color"]>, string> = {
+    red: "text-red-500",
+    blue: "text-blue-500",
+  };
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center rounded-lg bg-gray-100 px-7 py-4 md:px-9 md:py-6">
+      {/* 항목 이름 */}
+      <span>{content}</span>
+
+      {/* 오늘 추가된 건이 있다면 New 아이콘 표시 */}
+      {isTodayUpdated && (
+        <div className="ml-2 flex h-3.5 w-3.5 select-none items-center justify-center rounded-full bg-red-500">
+          <span className="font-bold text-[8px] text-white leading-none">
+            N
+          </span>
+        </div>
+      )}
+
+      {/* 항목 건수 */}
+      <span
+        className={`${colorStyle[color]} ml-auto font-bold text-lg md:text-xl`}
+      >
+        {count}
+      </span>
+    </div>
+  );
+}

--- a/src/features/StatusSummaryCard.tsx
+++ b/src/features/StatusSummaryCard.tsx
@@ -2,19 +2,14 @@ interface Props {
   content: string;
   isTodayUpdated?: boolean;
   count: number;
-  color?: "red" | "blue";
 }
 
 export default function StatusSummaryCard({
   content,
   isTodayUpdated = false,
   count,
-  color = "red",
 }: Props) {
-  const colorStyle: Record<NonNullable<Props["color"]>, string> = {
-    red: "text-red-500",
-    blue: "text-blue-500",
-  };
+  const hasCount = count > 0;
 
   return (
     <div className="flex min-w-0 flex-1 items-center rounded-lg bg-gray-100 px-7 py-4 md:px-9 md:py-6">
@@ -32,7 +27,7 @@ export default function StatusSummaryCard({
 
       {/* 항목 건수 */}
       <span
-        className={`${colorStyle[color]} ml-auto font-bold text-lg md:text-xl`}
+        className={`${hasCount ? "text-red-500" : "text-gray-400"} ml-auto font-bold text-lg md:text-xl`}
       >
         {count}
       </span>


### PR DESCRIPTION
## 내용

- 홈 페이지 생성
- 홈 페이지에서 신고/문의 처리 현황 표시
- 항목: 사용자 신고 & 게시글/댓글 신고 & 문의
- 건수, 오늘 추가된 건수 있는지(New) 표시
- 처리 현황 카드 클릭 시 해당하는 링크로 이동


## 화면
desktop
<img width="1481" alt="kokkok-admin-git-feat-dashboard-heony704s-projects vercel app_" src="https://github.com/user-attachments/assets/15036a9f-be79-494e-9a25-7fb220e4d5d3" />

mobile
<img width="300" alt="kokkok-admin-git-feat-dashboard-heony704s-projects vercel app_(iPhone SE)" src="https://github.com/user-attachments/assets/8cbf31dd-9706-44cc-b706-35cea7af14f7" />

